### PR TITLE
Update hypatia runtime to 46

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.github.HypatiaProject.hypatia.json
+++ b/com.github.HypatiaProject.hypatia.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.github.HypatiaProject.hypatia",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "42",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "hypatia",
     "finish-args" : [
@@ -13,9 +13,12 @@
     ],
     "cleanup" : [
         "/include",
+        "/lib/girepository-1.0",
         "/lib/pkgconfig",
         "/man",
         "/share/doc",
+        "/share/gir-1.0",
+        "/share/glib-2.0",
         "/share/gtk-doc",
         "/share/man",
         "/share/pkgconfig",
@@ -24,6 +27,7 @@
         "*.a"
     ],
     "modules" : [
+        "shared-modules/libsoup/libsoup-2.4.json",
         {
             "name" : "hypatia",
             "builddir" : true,
@@ -33,6 +37,10 @@
                     "type" : "archive",
                     "url" : "https://github.com/HypatiaProject/hypatia/archive/refs/tags/0.1.1.tar.gz",
                     "sha256" : "837bcd387d71612c9978971ee1446b603ff9632605cb6e1e856d4c254c1b8d2f"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "fix_appdata.patch"
                 }
             ]
         }

--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,35 @@
+diff --git a/data/com.github.HypatiaProject.hypatia.appdata.xml.in b/data/com.github.HypatiaProject.hypatia.appdata.xml.in
+index bace45b..aae431a 100644
+--- a/data/com.github.HypatiaProject.hypatia.appdata.xml.in
++++ b/data/com.github.HypatiaProject.hypatia.appdata.xml.in
+@@ -5,12 +5,15 @@
+   <metadata_license>CC0</metadata_license>
+   <project_license>GPL-3.0+</project_license>
+   <name>Hypatia</name>
+-  <summary>A research helper tool that provides context and information about
+-    interesting topics.
+-  </summary>
++  <summary>A research helper tool that provides context and information about interesting topics</summary>
+   <developer_name>Nathan Dyer and Hypatia Project Contributors</developer_name>
++  <developer id="io.github.hypatiaproject">
++    <name>Nathan Dyer and Hypatia Project Contributors</name>
++  </developer>
++
+   <url type="homepage">https://github.com/HypatiaProject/hypatia</url>
+   <url type="bugtracker">https://github.com/HypatiaProject/hypatia/issues</url>
++  <url type="vcs-browser">https://github.com/HypatiaProject/hypatia</url>
+ 
+   <screenshots>
+     <screenshot type="default">
+diff --git a/data/com.github.HypatiaProject.hypatia.desktop.in b/data/com.github.HypatiaProject.hypatia.desktop.in
+index 4eacdc6..e1cc849 100644
+--- a/data/com.github.HypatiaProject.hypatia.desktop.in
++++ b/data/com.github.HypatiaProject.hypatia.desktop.in
+@@ -4,5 +4,6 @@ Exec=hypatia
+ Icon=com.github.HypatiaProject.hypatia
+ Terminal=false
+ Type=Application
+-Categories=GTK;
++Categories=Utility;
++Keywords=Research;Wikipedia;Wiktionary;definition;explanation;
+ StartupNotify=true


### PR DESCRIPTION
- runtime: Update runtime to 46
- build: Add missing libsoup from shared modules
- appdata: Add vcs-browser URL and developer block
- desktop: Fix category related issues and add a few keywords